### PR TITLE
Make mousemove functionality work

### DIFF
--- a/js/mappoc.js
+++ b/js/mappoc.js
@@ -755,4 +755,4 @@ window.onload = function() {
   viewFolder.open();
 };
 
-window.onmousemove=Map.cellUnderMouse(event);
+window.onmousemove=Map.cellUnderMouse.bind(Map);


### PR DESCRIPTION
The prior code tried to make the onmousemove behaviour be the result of calling the intended function with an event variable that obviously isn't set. The new code actually sets the behaviour to a wrapper of the intended function but that sets the intended function's `this` to `Map`.